### PR TITLE
release: v5.1.0 with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,14 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           lfs: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -26,7 +27,7 @@ jobs:
           pytest tests/ -q
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -43,6 +44,6 @@ jobs:
         run: npm run build:types
 
       - name: Publish package
-        run: npm publish
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 /build
 *.egg-info/
 node_modules/
+.npmrc
 
 # IDEs and editors
 .agents/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokemon-tcg-pocket-cards",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "JSON database and TypeScript definitions for Pokémon TCG Pocket cards",
   "author": "Leonid Dalin & Chase Manning",
   "license": "AGPL-3.0-or-later",
@@ -26,7 +26,9 @@
     "./package.json": "./package.json"
   },
   "types": "./data/v5/cards.d.ts",
-  "files": ["data"],
+  "files": [
+    "data"
+  ],
   "scripts": {
     "build:types": "json2ts -i data/v5/cards.schema.json -o data/v5/cards.d.ts && json2ts -i data/v5/expansions.schema.json -o data/v5/expansions.d.ts"
   },


### PR DESCRIPTION
- Bump actions/checkout, actions/setup-python, and actions/setup-node to @v7
- Enable npm trusted publishing via OIDC with id-token: write permissions
- Add --provenance flag to publish step in publish.yml
- Sync package version to 5.1.0