### PR TITLE
Pipeline hygiene: widen the CDN allowlist, drop dead constants, extract PackResolver

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -70,9 +70,6 @@ ROOT_DIR = os.path.dirname(SCRIPT_DIR)
 
 # Versioned data
 DATA_DIR = os.path.join(ROOT_DIR, "data")
-V1_JSON_PATH = os.path.join(DATA_DIR, "v1", "cards.json")
-V2_JSON_PATH = os.path.join(DATA_DIR, "v2", "cards.json")
-V3_JSON_PATH = os.path.join(DATA_DIR, "v3", "cards.json")
 V4_JSON_PATH = os.path.join(DATA_DIR, "v4", "cards.json")
 V4_EXPANSIONS_JSON_PATH = os.path.join(DATA_DIR, "v4", "expansions.json")  # frozen v4-era index
 V5_DIR = os.path.join(DATA_DIR, "v5")

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 import os
+import re
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -35,6 +36,11 @@ GITHUB_BASE_URL = (
 V5_CARDS_URL_BASE = (
     "https://raw.githubusercontent.com/chase-manning/"
     "pokemon-tcg-pocket-cards/refs/heads/main/data/v5"
+)
+LIMITLESS_HOST = re.compile(
+    r"^limitlesstcg\.com$"
+    r"|^[a-z0-9-]+\.limitlesstcg\.com$"
+    r"|^limitlesstcg\.[a-z0-9-]+\.cdn\.digitaloceanspaces\.com$"
 )
 SEREBII_BASE_URL = "https://www.serebii.net/tcgpocket/"
 FLIBUSTIER_PTCGP_DB_URL = "https://cdn.jsdelivr.net/npm/pokemon-tcg-pocket-database@latest/dist/cards.json"

--- a/scripts/downloader.py
+++ b/scripts/downloader.py
@@ -26,24 +26,12 @@ Both functions skip files that already exist on disk.
 
 import io
 import os
-import re
 import time
 from PIL import Image
 from tqdm import tqdm
-from constants import WEBP_CARDS_DIR, PNG_CARDS_DIR, WEBP_PACKS_DIR, PNG_PACKS_DIR, SEREBII_BASE_URL, SESSION, RATE_LIMIT_DELAY, IMAGE_TIMEOUT, DEFAULT_TIMEOUT
+from constants import WEBP_CARDS_DIR, PNG_CARDS_DIR, WEBP_PACKS_DIR, PNG_PACKS_DIR, SEREBII_BASE_URL, SESSION, RATE_LIMIT_DELAY, IMAGE_TIMEOUT, DEFAULT_TIMEOUT, LIMITLESS_HOST
 from urllib.parse import urlsplit
 from utils import serebii_slug
-
-# Limitless serves artwork from its own CDN, not from limitlesstcg.com.
-# The host is either the bare domain, a subdomain of it, or one of its
-# DigitalOcean Spaces endpoints, which keep limitlesstcg as the first
-# label. Anchored at both ends so a lookalike host such as
-# limitlesstcg.com.evil.com cannot pass.
-_LIMITLESS_HOST = re.compile(
-    r"^limitlesstcg\.com$"
-    r"|^[a-z0-9-]+\.limitlesstcg\.com$"
-    r"|^limitlesstcg\.(nyc3|sfo3|ams3|fra1|sgp1|blr1)\.cdn\.digitaloceanspaces\.com$"
-)
 
 def download_images(cards, prefix):
     r"""download_images(cards, prefix)
@@ -97,7 +85,7 @@ def download_images(cards, prefix):
                     parsed_url is None
                     or parsed_url.scheme != "https"
                     or not hostname
-                    or not _LIMITLESS_HOST.match(hostname.lower())
+                    or not LIMITLESS_HOST.match(hostname.lower())
             ):
                 raise RuntimeError(f"Missing or invalid source_url for {card['id']}")
             try:

--- a/scripts/pack_resolver.py
+++ b/scripts/pack_resolver.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2024 Chase Manning <chase@manning.dev>
+# Copyright (C) 2026 Leonid Dalin <infoLeonid@protonmail.com> & Chase Manning <chase@manning.dev>
+#
+# Original code by Chase Manning is released under the MIT License.
+# Modifications and additions for version 5 onwards are released under
+# the GNU Affero General Public License v3.0 (AGPL-3.0-or-later).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+r"""Resolve a card's published pack name from its scraped pack value.
+
+Promo-A groups its cards into numbered volumes of
+:data:`constants.PROMO_CARDS_PER_VOLUME`, which is only knowable from the
+cards seen before this one, so this is an object with state rather than a
+pure function. Create one per set and call :meth:`resolve` once per card in
+printed order.
+"""
+
+from constants import PROMO_CARDS_PER_VOLUME
+
+
+class PackResolver:
+    r"""Maps a scraped pack value onto the published one for a set."""
+
+    def __init__(self, set_profile, expansion_name, specific_packs):
+        self._set = set_profile
+        self._expansion_name = expansion_name
+        self._specific_packs = specific_packs
+        self._volume = 1
+        self._volume_count = 0
+
+    def resolve(self, card):
+        r"""resolve(card) -> str
+
+        Args:
+            card (dict): a raw scraped card. Reads ``pack`` only.
+
+        Returns:
+            str: the published pack name.
+        """
+        pack = card["pack"]
+        if self._set.is_promo_a:
+            return self._promo_a(pack)
+        if self._set.is_promo:
+            return self._expansion_name
+        if pack == "Every pack":
+            return f"Shared({self._expansion_name})" if self._specific_packs else self._expansion_name
+        if pack.endswith(" pack"):
+            return pack[:-5].strip()
+        return pack
+
+    def _promo_a(self, pack):
+        if pack == "Promo pack":
+            self._volume_count += 1
+            if self._volume_count > PROMO_CARDS_PER_VOLUME:
+                self._volume, self._volume_count = self._volume + 1, 1
+            return f"Promo V{self._volume}"
+        if pack == "Every pack":
+            return self._expansion_name
+        return pack

--- a/scripts/transformer.py
+++ b/scripts/transformer.py
@@ -30,10 +30,11 @@ supports two output formats: ``v5`` (the full enriched schema) and
 import re
 import requests
 from functools import lru_cache
-from constants import SESSION, FLIBUSTIER_PTCGP_DB_URL, GITHUB_BASE_URL, PACK_POINTS, PROMO_CARDS_PER_VOLUME, SHINY_PACK_POINTS, TAG_DEFINITIONS, DEFAULT_TIMEOUT
+from constants import SESSION, FLIBUSTIER_PTCGP_DB_URL, GITHUB_BASE_URL, PACK_POINTS, SHINY_PACK_POINTS, TAG_DEFINITIONS, DEFAULT_TIMEOUT
 from utils import set_code_to_prefix, compile_tag_matchers
 from deck_code import get_deck_builder_nr
 from art_style import ArtStyleClassifier
+from pack_resolver import PackResolver
 
 @lru_cache(maxsize=1)
 def fetch_datamine_lookup():
@@ -205,7 +206,7 @@ def transform_cards(raw_cards, set_profile, expansion_name, release_date=None):
         gives a first card with ``id`` ``"a1-001"`` and ``name`` ``"Bulbasaur"``.
     """
     specific_packs = {c["pack"] for c in raw_cards if c["pack"] != "Every pack"}
-    promo_volume, promo_volume_count = 1, 0
+    packs = PackResolver(set_profile, expansion_name, specific_packs)
     art_styles = ArtStyleClassifier()
     datamine_lookup = fetch_datamine_lookup()
     tag_matchers = compile_tag_matchers(TAG_DEFINITIONS)
@@ -220,18 +221,7 @@ def transform_cards(raw_cards, set_profile, expansion_name, release_date=None):
         pack_points = None if set_profile.is_promo else (SHINY_PACK_POINTS if shiny else PACK_POINTS).get(rarity)
         if set_profile.is_promo: rarity = "Promo"
 
-        pack = card["pack"]
-        if set_profile.is_promo_a:
-            if pack == "Promo pack":
-                promo_volume_count += 1
-                if promo_volume_count > PROMO_CARDS_PER_VOLUME:
-                    promo_volume, promo_volume_count = promo_volume + 1, 1
-                pack = f"Promo V{promo_volume}"
-            elif pack == "Every pack":
-                pack = expansion_name
-        elif set_profile.is_promo: pack = expansion_name
-        elif pack == "Every pack": pack = f"Shared({expansion_name})" if specific_packs else expansion_name
-        elif pack.endswith(" pack"): pack = pack[:-5].strip()
+        pack = packs.resolve(card)
 
         try:
             deck_builder_nr = datamine_lookup.get((set_profile.prefix.lower(), int(re.sub(r"\D", "", card["number"]))))

--- a/tests/test_pack_resolver.py
+++ b/tests/test_pack_resolver.py
@@ -1,0 +1,39 @@
+"""Unit tests for pack resolution, exercised without the full transform."""
+from pack_resolver import PackResolver
+from set_profile import SetProfile
+
+
+def card(pack):
+    return {"pack": pack}
+
+
+def resolve_all(set_code, expansion_name, packs, specific=frozenset()):
+    r = PackResolver(SetProfile.of(set_code), expansion_name, specific)
+    return [r.resolve(card(p)) for p in packs]
+
+
+class TestRegularSets:
+    def test_pack_suffix_is_stripped(self):
+        assert resolve_all("A1", "Genetic Apex", ["Mewtwo pack"]) == ["Mewtwo"]
+
+    def test_every_pack_becomes_shared_when_named_packs_exist(self):
+        assert resolve_all("A1", "Genetic Apex", ["Every pack"], {"Mewtwo pack"}) == \
+               ["Shared(Genetic Apex)"]
+
+    def test_every_pack_becomes_the_expansion_when_it_is_the_only_pack(self):
+        assert resolve_all("B3b", "Everyday Wonders", ["Every pack"]) == ["Everyday Wonders"]
+
+
+class TestPromo:
+    def test_promo_a_groups_promo_packs_into_volumes_of_five(self):
+        got = resolve_all("P-A", "Promo-A", ["Promo pack"] * 11)
+        assert got[:5] == ["Promo V1"] * 5
+        assert got[5:10] == ["Promo V2"] * 5
+        assert got[10] == "Promo V3"
+
+    def test_promo_a_keeps_named_promo_packs(self):
+        assert resolve_all("P-A", "Promo-A", ["Premium Missions", "Shop"]) == \
+               ["Premium Missions", "Shop"]
+
+    def test_promo_b_cards_land_on_the_expansion_name(self):
+        assert resolve_all("P-B", "Promo-B", ["Every pack"]) == ["Promo-B"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -230,3 +230,20 @@ class TestStripSourceUrls:
         cards = [{"id": "a1-001", "source_url": "https://x/1.webp"}, {"id": "a1-002"}]
         strip_source_urls(cards)
         assert cards == [{"id": "a1-001"}, {"id": "a1-002"}]
+
+
+class TestLimitlessHostAllowlist:
+    @pytest.mark.parametrize("host, accepted", [
+        ("limitlesstcg.com", True),
+        ("cdn.limitlesstcg.com", True),
+        ("limitlesstcg.nyc3.cdn.digitaloceanspaces.com", True),
+        ("limitlesstcg.tor1.cdn.digitaloceanspaces.com", True),
+        ("limitlesstcg.com.evil.com", False),
+        ("evil-limitlesstcg.com", False),
+        ("evil.limitlesstcg.nyc3.cdn.digitaloceanspaces.com", False),
+        ("attacker.nyc3.cdn.digitaloceanspaces.com", False),
+        ("limitlesstcg.nyc3.cdn.digitaloceanspaces.com.evil.com", False),
+    ])
+    def test_host_allowlist(self, host, accepted):
+        from constants import LIMITLESS_HOST
+        assert bool(LIMITLESS_HOST.match(host)) is accepted


### PR DESCRIPTION
## What this does

Three independent pipeline hygiene fixes, none touching published data.

- The CDN host allowlist in `downloader.py` enumerated six DigitalOcean Spaces regions. A Spaces hostname puts the bucket in the first label, so pinning the bucket is what makes the guard safe; the region list added no safety and would break the next time the CDN moves regions, which is the outage `f0f9784` fixed. The allowlist now accepts any region and lives in `constants.py` with the other URLs, covered by a parametrised test.
- `constants.py` carried `V1/V2/V3_JSON_PATH`, left behind when the v5 refactor deleted their only reader. They are removed. `SCRIPT_DIR` and `IMAGES_DIR` stay: both are used inside the module as the base of other paths.
- `transform_cards` carried the promo volume counters across loop iterations. That state is now `PackResolver`, mirroring how the art-style state became `ArtStyleClassifier`. The 31-key card dict stays inline; a 12-argument builder would be longer than the literal it replaced.

## Verification

`python -m pytest -q` reports 455 passed. `compile_v5_database()` produces byte-identical output. No `data/` or `images/` files changed.
