### PR TITLE
fix(data): read the set directories in sorted order

### DIFF
--- a/scripts/database.py
+++ b/scripts/database.py
@@ -81,13 +81,18 @@ def read_all_v5_cards():
     directory (e.g. ``a1/a1.json``). Cards from all sets are collected
     into a single flat list.
 
+    Directories are walked in sorted order. Filesystem order varies by
+    platform, and the published payloads are built from this list, so an
+    unsorted walk would rewrite every payload on a machine whose
+    directory order differs from the one that last wrote them.
+
     Returns:
         list of dict: all cards across all sets. Each dict is the
         card in v5 format as written by :func:`write_set_file` or
         :func:`compile_v5_database`.
     """
     cards = []
-    for item in os.listdir(V5_DIR):
+    for item in sorted(os.listdir(V5_DIR)):
         set_dir = os.path.join(V5_DIR, item)
         if os.path.isdir(set_dir):
             cards.extend(_load_existing_json(os.path.join(set_dir, f"{item}.json")))

--- a/tests/test_payload_freshness.py
+++ b/tests/test_payload_freshness.py
@@ -20,6 +20,13 @@ def cards():
     return database.read_all_v5_cards()
 
 
+def test_read_order_is_stable_across_filesystems():
+    """The payloads are built from this list, so its order must not
+    depend on the filesystem. Sorted is the order the data ships in."""
+    order = [card["set_code"] for card in database.read_all_v5_cards()]
+    assert order == sorted(order), "read_all_v5_cards returned filesystem order"
+
+
 def _pretty(records):
     return json.dumps(records, indent=2, ensure_ascii=False)
 


### PR DESCRIPTION
Merging #76 turned `main` red. The cause was not the merge.

`read_all_v5_cards` walks `data/v5` with `os.listdir`, which returns
filesystem order. That order differs between platforms. Every payload is
built from that list, so on a runner whose directory order differs from
the machine that last wrote the data, all twelve root payloads compare as
stale and the freshness guard fails, even though no value changed.

Windows happened to return sorted order, which is why the branch was green
locally and red in CI lmao

The walk is now sorted, and a test asserts the list comes back ordered, so
the next filesystem-dependent read fails where it is introduced rather than
at the far end of the pipeline.

No data changes: the committed payloads were already in sorted order, so
sorting reproduces them byte for byte. `git status --porcelain data` is
empty after a full regeneration.

Gate: 515 passed (514 plus the new order test)
