### PR TITLE
docs: show the trading fields on the full payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cards); full and collection additionally keep all 3,879 printed cards.
 | gameplay no-image | 1.24 MB | Gameplay with the image URL dropped |
 | collection | 2.99 MB | One record per printed card, trading fields derived |
 | collection no-image | 1.98 MB | Collection with the image URL dropped |
-| full | 4.77 MB | Everything the scraper extracts, all 3,879 cards |
+| full | 4.77 MB | Everything the scraper extracts, all 3,879 cards, trading fields included |
 
 ### 💼 Support schedule
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ npm install pokemon-tcg-pocket-cards
 | `pokemon-tcg-pocket-cards/gameplay/no-image` | Alias of `/v5/gameplay/no-image` for existing consumers |
 | `pokemon-tcg-pocket-cards/v5/collection` | Collection view: one record per printed card, trading fields derived |
 | `pokemon-tcg-pocket-cards/collection` | Alias of `/v5/collection` for existing consumers |
+| `pokemon-tcg-pocket-cards/v5/collection/no-image` | Collection view without the image URL |
+| `pokemon-tcg-pocket-cards/collection/no-image` | Alias of `/v5/collection/no-image` for existing consumers |
 | `pokemon-tcg-pocket-cards/v5/expansions` | Expansions and packs (pinned to v5) |
 | `pokemon-tcg-pocket-cards/expansions` | Expansions and packs (latest) |
 | `pokemon-tcg-pocket-cards/v4` | Legacy v4 card dataset |
@@ -85,6 +87,29 @@ Every dataset now lives under [data/](data/). If you link to a raw file at the r
 | `/v3.json`             | [data/v3/cards.json](data/v3/cards.json) ([minified](data/v3/cards.min.json))   |
 | `/v4.json`             | [data/v4/cards.json](data/v4/cards.json) ([minified](data/v4/cards.min.json))   |
 
+## 📊 Schema comparison
+
+The full per-payload field comparison lives in
+[docs/payloads.md](docs/payloads.md#field-comparison-across-payloads). In
+short, all v5 projections share the same card range (2,822 gameplay-rarity
+cards); full and collection additionally keep all 3,879 printed cards.
+
+| Payload | Minified size | Purpose |
+| --- | --- | --- |
+| core | 0.96 MB | Slim summary per gameplay card, webp image included |
+| core no-image | 0.59 MB | Core with the image URL dropped |
+| gameplay | 1.61 MB | Combat model: attacks, abilities, combat stats |
+| gameplay no-image | 1.24 MB | Gameplay with the image URL dropped |
+| collection | 2.99 MB | One record per printed card, trading fields derived |
+| collection no-image | 1.98 MB | Collection with the image URL dropped |
+| full | 4.77 MB | Everything the scraper extracts, all 3,879 cards |
+
+### 💼 Support schedule
+
+[💚 V5](data/v5/cards.json) is the actively maintained data model.
+[💛 V4](data/v4/cards.min.json) receives updates until the end of the "B" block (its final expansion).
+Versions [V3](data/v3/cards.json) and earlier are fully deprecated and no longer updated.
+
 ## ⚡ Adding a new expansion
 
 When a new expansion drops, run the script to scrape card data, download card art, and update the JSON files.
@@ -120,27 +145,6 @@ python3 scripts/add_expansion.py PB
 - Pass `--name "Custom Name"` to override the expansion name.
 - Pass `--skip-images` to skip downloading images.
 - Pass `--mode v4` to format the output for the legacy schema.
-
-## 📊 Schema comparison
-
-The full per-payload field comparison lives in
-[docs/payloads.md](docs/payloads.md#field-comparison-across-payloads). In
-short, all v5 projections share the same card range (2,822 gameplay-rarity
-cards); full and collection additionally keep all 3,879 printed cards.
-
-| Payload | Minified size | Purpose |
-| --- | --- | --- |
-| core | ~0.96 MB | Slim summary per gameplay card, webp image included |
-| core no-image | ~0.59 MB | Core with the image URL dropped |
-| gameplay | ~1.61 MB | Combat model: attacks, abilities, combat stats |
-| collection | ~2.99 MB | One record per printed card, trading fields derived |
-| full | ~4.58 MB | Everything the scraper extracts, all 3,879 cards |
-
-### 💼 Support schedule
-
-[💚 V5](data/v5/cards.json) is the actively maintained data model.
-[💛 V4](data/v4/cards.min.json) receives updates until the end of the "B" block (its final expansion).
-Versions [V3](data/v3/cards.json) and earlier are fully deprecated and no longer updated.
 
 ## 🤝 Contributing
 

--- a/docs/payloads.md
+++ b/docs/payloads.md
@@ -89,7 +89,8 @@ Trading fields (derived from rarity):
 
 The complete dataset: collection metadata (`set_name`, `pack`, `release_date`,
 `pack_points`, `rarity`, `art_style`, `artist`, `flavour_text`,
-`alternate_versions`), images in both formats, and every gameplay field.
+`alternate_versions`), the trading fields (`tradable`, `sharable`,
+`trade_cost`), images in both formats, and every gameplay field.
 Records keep all 30 keys with `null` for fields that do not apply. Licensed
 AGPL-3.0-or-later like the rest of version 5. Schema:
 [cards.schema.json](../data/v5/cards.schema.json) ·
@@ -207,7 +208,7 @@ smallest set (a4b, 379 cards; a1a, 86 cards):
 | Attacks and abilities | ❌ | ✅ nested | ❌ | ✅ nested |
 | Rules text (`card_text`) | ❌ | ✅ | ❌ | ✅ |
 | Rarity and collection metadata | ❌ | ❌ | ✅ | ✅ |
-| Trading fields (`tradable`, `sharable`, `trade_cost`) | ❌ | ❌ | ✅ | ❌ |
+| Trading fields (`tradable`, `sharable`, `trade_cost`) | ❌ | ❌ | ✅ | ✅ |
 | Images | ✅ webp | ✅ webp | ✅ webp + png | ✅ webp + png |
 | Flavour text, artist, alternate prints | ❌ | ❌ | ✅ | ✅ |
 

--- a/scripts/projections.py
+++ b/scripts/projections.py
@@ -28,10 +28,7 @@ is the only caller.
 import os
 
 from constants import (COLLECTION_FIELDS, CORE_RARITIES, GAMEPLAY_FIELDS,
-                       GAMEPLAY_NO_IMAGE_FIELDS, is_playable_trainer,
-                       V5_COLLECTION_CARDS_PATH, V5_COLLECTION_NO_IMAGE_CARDS_PATH,
-                       V5_CORE_CARDS_PATH, V5_CORE_NO_IMAGE_CARDS_PATH,
-                       V5_GAMEPLAY_CARDS_PATH, V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
+                       GAMEPLAY_NO_IMAGE_FIELDS, V5_DIR, is_playable_trainer)
 from utils import minified_path, write_json_pair
 
 
@@ -260,6 +257,21 @@ SHARD_VARIANTS = (
     ("collection.no-image", "cards_collection_no_image",
      "cards.collection.no-image.json", build_collection_no_image_cards),
 )
+
+#: Maps a variant to the absolute path of its root payload. Derived from
+#: :data:`SHARD_VARIANTS` so the filename is stated once; the tests read
+#: the paths from here rather than from ``constants``.
+ROOT_PATHS = {variant: os.path.join(V5_DIR, filename)
+              for variant, _url_stem, filename, _builder in SHARD_VARIANTS}
+
+# The six names the tests import. Built from ROOT_PATHS so the filename
+# is stated once, in the table.
+V5_CORE_CARDS_PATH = ROOT_PATHS["core"]
+V5_CORE_NO_IMAGE_CARDS_PATH = ROOT_PATHS["core.no-image"]
+V5_GAMEPLAY_CARDS_PATH = ROOT_PATHS["gameplay"]
+V5_GAMEPLAY_NO_IMAGE_CARDS_PATH = ROOT_PATHS["gameplay.no-image"]
+V5_COLLECTION_CARDS_PATH = ROOT_PATHS["collection"]
+V5_COLLECTION_NO_IMAGE_CARDS_PATH = ROOT_PATHS["collection.no-image"]
 
 
 def shard_path(prefix, variant, v5_dir, minified=False):

--- a/scripts/transformer.py
+++ b/scripts/transformer.py
@@ -156,6 +156,36 @@ def strip_source_urls(cards):
         card.pop("source_url", None)
 
 
+def _trade_rule(rarity, shiny, art_style, card):
+    r"""_trade_rule(rarity, shiny, art_style, card) -> tuple
+
+    Look a card up in :data:`TRADE_RULES`. An unknown combination raises
+    with the card identified, so a new rarity fails the scrape naming
+    the print that caused it rather than with a bare KeyError carrying
+    only the tuple.
+
+    Args:
+        rarity (str): the card's rarity
+        shiny (bool): whether the classifier marked it shiny
+        art_style (str | None): the card's art style
+        card (dict): the raw card, used only to name it on failure
+
+    Returns:
+        tuple: ``(tradable, sharable, trade_cost)``
+
+    Raises:
+        KeyError: the combination is not in ``TRADE_RULES``
+    """
+    key = (rarity, shiny, art_style)
+    try:
+        return TRADE_RULES[key]
+    except KeyError:
+        raise KeyError(
+            f"no trade rule for {key} "
+            f"(card {card.get('name')!r}, number {card.get('number')!r})"
+        ) from None
+
+
 def transform_cards(raw_cards, set_profile, expansion_name, release_date=None):
     r"""transform_cards(raw_cards, set_profile, expansion_name, release_date=None) -> list of dict
 
@@ -222,6 +252,7 @@ def transform_cards(raw_cards, set_profile, expansion_name, release_date=None):
         if set_profile.is_promo:
             rarity = "Promo"
             art_style = None
+            shiny = False
 
         pack = packs.resolve(card)
 
@@ -234,7 +265,8 @@ def transform_cards(raw_cards, set_profile, expansion_name, release_date=None):
             deck_builder_nr = 0
         matched_tags = [tag for tag, regex in tag_matchers.items() if regex.search(card["name"])]
         special_tags = matched_tags if matched_tags else None
-        tradable, sharable, card_trade_cost = TRADE_RULES[(rarity, shiny, art_style)]
+        tradable, sharable, card_trade_cost = _trade_rule(
+            rarity, shiny, art_style, card)
 
         transformed.append({
             # Core identifiers

--- a/tests/test_collection_payload.py
+++ b/tests/test_collection_payload.py
@@ -4,10 +4,9 @@ import json
 
 import jsonschema
 
-from constants import (CARDS_JSON_PATH, TRADE_RULES, V5_COLLECTION_CARDS_PATH,
-                       V5_COLLECTION_CARDS_SCHEMA_PATH,
-                       V5_COLLECTION_NO_IMAGE_CARDS_PATH,
-                       V5_COLLECTION_NO_IMAGE_CARDS_SCHEMA_PATH)
+from constants import (
+    CARDS_JSON_PATH, TRADE_RULES, V5_COLLECTION_CARDS_SCHEMA_PATH, V5_COLLECTION_NO_IMAGE_CARDS_SCHEMA_PATH)
+import projections as P
 
 GAMEPLAY_ONLY_FIELDS = {"attacks", "ability", "health"}
 
@@ -32,14 +31,14 @@ def _load(path):
 
 def test_collection_has_one_record_per_printed_card():
     full = _load(CARDS_JSON_PATH)
-    collection = _load(V5_COLLECTION_CARDS_PATH)
+    collection = _load(P.V5_COLLECTION_CARDS_PATH)
     assert len(full) == 3879
     assert len(collection) == 3879
     assert {card["id"] for card in full} == {card["id"] for card in collection}
 
 
 def test_collection_records_all_carry_trading_fields():
-    collection = _load(V5_COLLECTION_CARDS_PATH)
+    collection = _load(P.V5_COLLECTION_CARDS_PATH)
     assert collection
     for record in collection:
         assert "tradable" in record
@@ -48,14 +47,14 @@ def test_collection_records_all_carry_trading_fields():
 
 
 def test_collection_trade_rules_cover_every_record():
-    collection = _load(V5_COLLECTION_CARDS_PATH)
+    collection = _load(P.V5_COLLECTION_CARDS_PATH)
     for record in collection:
         key = (record["rarity"], record.get("shiny", False), record.get("art_style"))
         assert key in TRADE_RULES, key
 
 
 def test_collection_trade_values_match_the_rule_table():
-    collection = _load(V5_COLLECTION_CARDS_PATH)
+    collection = _load(P.V5_COLLECTION_CARDS_PATH)
     seen = set()
     for record in collection:
         key = (record["rarity"], record.get("shiny", False), record.get("art_style"))
@@ -67,7 +66,7 @@ def test_collection_trade_values_match_the_rule_table():
 
 
 def test_collection_trade_spot_checks_per_bucket():
-    collection = _load(V5_COLLECTION_CARDS_PATH)
+    collection = _load(P.V5_COLLECTION_CARDS_PATH)
     for key, expected in TRADE_SPOT_CHECKS.items():
         rarity, shiny, art_style = key
         matches = [
@@ -82,7 +81,7 @@ def test_collection_trade_spot_checks_per_bucket():
 
 
 def test_collection_crown_and_promo_are_not_tradable():
-    collection = _load(V5_COLLECTION_CARDS_PATH)
+    collection = _load(P.V5_COLLECTION_CARDS_PATH)
     for record in collection:
         if record["rarity"] in ("Crown Rare", "Promo"):
             assert record["tradable"] is False
@@ -91,22 +90,22 @@ def test_collection_crown_and_promo_are_not_tradable():
 
 
 def test_collection_records_carry_no_gameplay_only_fields():
-    collection = _load(V5_COLLECTION_CARDS_PATH)
+    collection = _load(P.V5_COLLECTION_CARDS_PATH)
     assert collection
     for record in collection:
         assert GAMEPLAY_ONLY_FIELDS.isdisjoint(record)
 
 
 def test_collection_matches_its_schema():
-    collection = _load(V5_COLLECTION_CARDS_PATH)
+    collection = _load(P.V5_COLLECTION_CARDS_PATH)
     schema = _load(V5_COLLECTION_CARDS_SCHEMA_PATH)
     jsonschema.validate(instance=collection, schema=schema)
 
 
 def test_collection_no_image_has_one_record_per_printed_card():
     full = _load(CARDS_JSON_PATH)
-    collection = _load(V5_COLLECTION_CARDS_PATH)
-    no_image = _load(V5_COLLECTION_NO_IMAGE_CARDS_PATH)
+    collection = _load(P.V5_COLLECTION_CARDS_PATH)
+    no_image = _load(P.V5_COLLECTION_NO_IMAGE_CARDS_PATH)
     assert len(full) == 3879
     assert len(no_image) == 3879
     assert len(collection) == len(no_image)
@@ -114,7 +113,7 @@ def test_collection_no_image_has_one_record_per_printed_card():
 
 
 def test_collection_no_image_records_carry_no_image_urls():
-    no_image = _load(V5_COLLECTION_NO_IMAGE_CARDS_PATH)
+    no_image = _load(P.V5_COLLECTION_NO_IMAGE_CARDS_PATH)
     assert no_image
     for record in no_image:
         assert "image" not in record
@@ -122,7 +121,7 @@ def test_collection_no_image_records_carry_no_image_urls():
 
 
 def test_collection_no_image_records_carry_trading_fields():
-    no_image = _load(V5_COLLECTION_NO_IMAGE_CARDS_PATH)
+    no_image = _load(P.V5_COLLECTION_NO_IMAGE_CARDS_PATH)
     for record in no_image:
         assert "tradable" in record
         assert "sharable" in record
@@ -130,6 +129,6 @@ def test_collection_no_image_records_carry_trading_fields():
 
 
 def test_collection_no_image_matches_its_schema():
-    no_image = _load(V5_COLLECTION_NO_IMAGE_CARDS_PATH)
+    no_image = _load(P.V5_COLLECTION_NO_IMAGE_CARDS_PATH)
     schema = _load(V5_COLLECTION_NO_IMAGE_CARDS_SCHEMA_PATH)
     jsonschema.validate(instance=no_image, schema=schema)

--- a/tests/test_core_no_image_payload.py
+++ b/tests/test_core_no_image_payload.py
@@ -3,9 +3,9 @@ import json
 
 import jsonschema
 
-from constants import (CARDS_JSON_PATH, CORE_RARITIES, V5_CORE_CARDS_PATH,
-                       V5_CORE_NO_IMAGE_CARDS_PATH, V5_CORE_NO_IMAGE_CARDS_SCHEMA_PATH,
-                       is_playable_trainer)
+from constants import (
+    CARDS_JSON_PATH, CORE_RARITIES, V5_CORE_NO_IMAGE_CARDS_SCHEMA_PATH, is_playable_trainer)
+import projections as P
 
 
 def _load(path):
@@ -16,8 +16,8 @@ def _load(path):
 
 def test_no_image_covers_the_same_cards_as_core():
     full = _load(CARDS_JSON_PATH)
-    core = _load(V5_CORE_CARDS_PATH)
-    no_image = _load(V5_CORE_NO_IMAGE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
+    no_image = _load(P.V5_CORE_NO_IMAGE_CARDS_PATH)
     kept_ids = {card["id"] for card in full if card["rarity"] in CORE_RARITIES}
     assert kept_ids == {card["id"] for card in core}
     assert kept_ids == {card["id"] for card in no_image}
@@ -25,14 +25,14 @@ def test_no_image_covers_the_same_cards_as_core():
 
 
 def test_no_image_matches_its_schema():
-    no_image = _load(V5_CORE_NO_IMAGE_CARDS_PATH)
+    no_image = _load(P.V5_CORE_NO_IMAGE_CARDS_PATH)
     schema = _load(V5_CORE_NO_IMAGE_CARDS_SCHEMA_PATH)
     jsonschema.validate(instance=no_image, schema=schema)
 
 
 def test_no_image_records_are_core_minus_image():
-    core = _load(V5_CORE_CARDS_PATH)
-    no_image = _load(V5_CORE_NO_IMAGE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
+    no_image = _load(P.V5_CORE_NO_IMAGE_CARDS_PATH)
     by_id = {record["id"]: record for record in core}
     for record in no_image:
         assert record == {key: value for key, value in by_id[record["id"]].items()
@@ -40,7 +40,7 @@ def test_no_image_records_are_core_minus_image():
 
 
 def test_no_image_trainer_records_omit_ex_and_mega():
-    no_image = _load(V5_CORE_NO_IMAGE_CARDS_PATH)
+    no_image = _load(P.V5_CORE_NO_IMAGE_CARDS_PATH)
     for record in no_image:
         if record["type"] == "Trainer":
             assert "ex" not in record
@@ -52,6 +52,6 @@ def test_no_image_trainer_records_omit_ex_and_mega():
 
 
 def test_no_image_tagged_card_carries_special_tags():
-    no_image = _load(V5_CORE_NO_IMAGE_CARDS_PATH)
+    no_image = _load(P.V5_CORE_NO_IMAGE_CARDS_PATH)
     record = next(r for r in no_image if r["id"] == "a3-088")
     assert record["special_tags"] == ["ultra_beasts"]

--- a/tests/test_core_payload.py
+++ b/tests/test_core_payload.py
@@ -4,8 +4,9 @@ import os
 
 import jsonschema
 
-from constants import (CARDS_JSON_PATH, CORE_RARITIES, V5_CORE_CARDS_PATH,
-                       V5_CORE_CARDS_SCHEMA_PATH, is_playable_trainer)
+from constants import (
+    CARDS_JSON_PATH, CORE_RARITIES, V5_CORE_CARDS_SCHEMA_PATH, is_playable_trainer)
+import projections as P
 from tests.contract import CORE_KEYS as CORE_FIELDS
 
 
@@ -17,7 +18,7 @@ def _load(path):
 
 def test_core_payload_covers_every_gameplay_card():
     full = _load(CARDS_JSON_PATH)
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     kept = {card["id"] for card in full if card["rarity"] in CORE_RARITIES}
     assert {card["id"] for card in core} == kept
 
@@ -26,7 +27,7 @@ def test_core_records_omit_inapplicable_keys():
     """A record keeps exactly the core fields the full card fills, minus the
     ex and mega keys Trainer cards always omit."""
     full = _load(CARDS_JSON_PATH)
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     by_id = {card["id"]: card for card in full}
     for record in core:
         source = by_id[record["id"]]
@@ -38,7 +39,7 @@ def test_core_records_omit_inapplicable_keys():
 
 def test_core_present_values_match_the_full_payload():
     full = _load(CARDS_JSON_PATH)
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     by_id = {card["id"]: card for card in full}
     for record in core:
         source = by_id[record["id"]]
@@ -47,12 +48,12 @@ def test_core_present_values_match_the_full_payload():
 
 
 def test_core_records_never_carry_null_values():
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     assert not any(record[key] is None for record in core for key in record)
 
 
 def test_core_fossil_items_keep_playable_fields():
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     fossils = [record for record in core if is_playable_trainer(record["name"])]
     assert fossils
     for record in fossils:
@@ -65,25 +66,25 @@ def test_core_fossil_items_keep_playable_fields():
 
 def test_core_payload_is_smaller_than_the_full_payload():
     full_size = os.path.getsize(CARDS_JSON_PATH.replace(".json", ".min.json"))
-    core_size = os.path.getsize(V5_CORE_CARDS_PATH.replace(".json", ".min.json"))
+    core_size = os.path.getsize(P.V5_CORE_CARDS_PATH.replace(".json", ".min.json"))
     assert core_size < full_size * 0.4
 
 
 def test_core_payload_matches_its_schema():
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     schema = _load(V5_CORE_CARDS_SCHEMA_PATH)
     jsonschema.validate(instance=core, schema=schema)
 
 
 def test_core_payload_excludes_cosmetic_rarities():
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     rarities = {card["rarity"] for card in core}
     assert rarities == set(CORE_RARITIES)
 
 
 def test_core_payload_drops_no_unique_gameplay_cards():
     full = _load(CARDS_JSON_PATH)
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     kept_ids = {card["id"] for card in core}
     kept_builder_numbers = {card["deckBuilderNr"] for card in core}
     excluded = [card for card in full if card["id"] not in kept_ids]
@@ -93,13 +94,13 @@ def test_core_payload_drops_no_unique_gameplay_cards():
 
 
 def test_core_tagged_card_carries_special_tags():
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     record = next(r for r in core if r["id"] == "a3-088")
     assert record["special_tags"] == ["ultra_beasts"]
 
 
 def test_core_untagged_records_omit_special_tags():
-    core = _load(V5_CORE_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
     untagged = [r for r in core if "special_tags" not in r]
     assert untagged
     for record in untagged:

--- a/tests/test_gameplay_no_image_payload.py
+++ b/tests/test_gameplay_no_image_payload.py
@@ -4,9 +4,9 @@ import json
 import jsonschema
 
 from tests.contract import GAMEPLAY_NO_IMAGE_KEYS
-from constants import (CARDS_JSON_PATH, CORE_RARITIES, V5_GAMEPLAY_CARDS_PATH,
-                       V5_GAMEPLAY_NO_IMAGE_CARDS_PATH,
-                       V5_GAMEPLAY_NO_IMAGE_CARDS_SCHEMA_PATH, is_playable_trainer)
+from constants import (
+    CARDS_JSON_PATH, CORE_RARITIES, V5_GAMEPLAY_NO_IMAGE_CARDS_SCHEMA_PATH, is_playable_trainer)
+import projections as P
 
 _TRAINER_DROPPED = {"stage", "health", "points", "weakness", "retreat",
                     "evolves_from", "ability", "attacks", "ex", "mega",
@@ -24,22 +24,22 @@ def _load(path):
 
 def test_no_image_covers_the_same_cards_as_gameplay():
     full = _load(CARDS_JSON_PATH)
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
-    no_image = _load(V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
+    no_image = _load(P.V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
     kept_ids = {card["id"] for card in full if card["rarity"] in CORE_RARITIES}
     assert kept_ids == {card["id"] for card in gameplay}
     assert kept_ids == {card["id"] for card in no_image}
 
 
 def test_no_image_matches_its_schema():
-    no_image = _load(V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
+    no_image = _load(P.V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
     schema = _load(V5_GAMEPLAY_NO_IMAGE_CARDS_SCHEMA_PATH)
     jsonschema.validate(instance=no_image, schema=schema)
 
 
 def test_no_image_records_are_gameplay_minus_image():
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
-    no_image = _load(V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
+    no_image = _load(P.V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
     by_id = {record["id"]: record for record in gameplay}
     for record in no_image:
         assert record == {key: value for key, value in by_id[record["id"]].items()
@@ -47,12 +47,12 @@ def test_no_image_records_are_gameplay_minus_image():
 
 
 def test_no_image_records_carry_no_image_key():
-    no_image = _load(V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
+    no_image = _load(P.V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
     assert not any("image" in record for record in no_image)
 
 
 def test_no_image_trainer_shapes_follow_trim_rule():
-    no_image = _load(V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
+    no_image = _load(P.V5_GAMEPLAY_NO_IMAGE_CARDS_PATH)
     for record in no_image:
         if record["type"] != "Trainer":
             continue

--- a/tests/test_gameplay_payload.py
+++ b/tests/test_gameplay_payload.py
@@ -4,9 +4,9 @@ import json
 import jsonschema
 
 from tests.contract import GAMEPLAY_KEYS
-from constants import (CARDS_JSON_PATH, CORE_RARITIES,
-                       V5_CORE_CARDS_PATH, V5_GAMEPLAY_CARDS_PATH,
-                       V5_GAMEPLAY_CARDS_SCHEMA_PATH, is_playable_trainer)
+from constants import (
+    CARDS_JSON_PATH, CORE_RARITIES, V5_GAMEPLAY_CARDS_SCHEMA_PATH, is_playable_trainer)
+import projections as P
 
 _TRAINER_DROPPED = {"stage", "health", "points", "weakness", "retreat",
                     "evolves_from", "ability", "attacks", "ex", "mega",
@@ -24,8 +24,8 @@ def _load(path):
 
 def test_gameplay_covers_the_same_cards_as_core():
     full = _load(CARDS_JSON_PATH)
-    core = _load(V5_CORE_CARDS_PATH)
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
+    core = _load(P.V5_CORE_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
     kept_ids = {card["id"] for card in full if card["rarity"] in CORE_RARITIES}
     assert kept_ids == {card["id"] for card in core}
     assert kept_ids == {card["id"] for card in gameplay}
@@ -33,14 +33,14 @@ def test_gameplay_covers_the_same_cards_as_core():
 
 
 def test_gameplay_records_carry_image():
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
     assert gameplay
     assert all(record["image"].startswith("https://raw.githubusercontent.com/")
                for record in gameplay)
 
 
 def test_gameplay_matches_its_schema():
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
     schema = _load(V5_GAMEPLAY_CARDS_SCHEMA_PATH)
     jsonschema.validate(instance=gameplay, schema=schema)
 
@@ -48,7 +48,7 @@ def test_gameplay_matches_its_schema():
 def test_gameplay_pokemon_records_match_source_projection():
     """Pokemon records keep the full combat projection, omitting only nulls."""
     full = _load(CARDS_JSON_PATH)
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
     by_id = {card["id"]: card for card in full}
     for record in gameplay:
         if record["type"] == "Trainer":
@@ -59,7 +59,7 @@ def test_gameplay_pokemon_records_match_source_projection():
 
 
 def test_gameplay_trainer_records_omit_combat_keys():
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
     for record in gameplay:
         if record["type"] != "Trainer":
             continue
@@ -82,14 +82,14 @@ def test_gameplay_trainer_records_omit_combat_keys():
 
 
 def test_gameplay_non_fossil_trainer_keeps_only_scalar_keys():
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
     sabrina = next(record for record in gameplay if record["id"] == "a1-225")
     assert sabrina["name"] == "Sabrina"
     assert set(sabrina) == NON_FOSSIL_TRAINER_KEYS
 
 
 def test_gameplay_fossil_trainer_keeps_combat_keys():
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
     helix = next(record for record in gameplay if record["id"] == "a1-216")
     assert helix["name"] == "Helix Fossil"
     assert set(helix) == FOSSIL_TRAINER_KEYS
@@ -100,7 +100,7 @@ def test_gameplay_fossil_trainer_keeps_combat_keys():
 
 
 def test_gameplay_trainer_shapes_follow_trim_rule():
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
     for record in gameplay:
         if record["type"] != "Trainer":
             continue
@@ -112,7 +112,7 @@ def test_gameplay_trainer_shapes_follow_trim_rule():
 
 
 def test_gameplay_schema_accepts_trimmed_trainer_records():
-    gameplay = _load(V5_GAMEPLAY_CARDS_PATH)
+    gameplay = _load(P.V5_GAMEPLAY_CARDS_PATH)
     schema = _load(V5_GAMEPLAY_CARDS_SCHEMA_PATH)
     for record in gameplay:
         if record["type"] == "Trainer":

--- a/tests/test_payload_freshness.py
+++ b/tests/test_payload_freshness.py
@@ -20,6 +20,20 @@ def cards():
     return database.read_all_v5_cards()
 
 
+TRADE_FIELDS = ("tradable", "sharable", "trade_cost")
+
+
+def test_full_carries_the_trading_fields():
+    """collection and full both carry them; the projections that drop
+    them are core and gameplay. Documented in docs/payloads.md."""
+    with open(os.path.join(V5_DIR, "cards.json"), encoding="utf-8") as f:
+        full = json.load(f)
+    assert full, "full payload is empty"
+    missing = [key for key in TRADE_FIELDS
+               if any(key not in record for record in full)]
+    assert not missing, f"full is missing {missing}; check payloads.md"
+
+
 def test_read_order_is_stable_across_filesystems():
     """The payloads are built from this list, so its order must not
     depend on the filesystem. Sorted is the order the data ships in."""


### PR DESCRIPTION
Four commits, all following on from #77.

**The variant table now owns the payload paths.** Switching
`SHARD_VARIANTS` to bare filenames left six absolute path constants in
`constants.py` imported by production but no longer used, and duplicated
those same six paths between the table and the constants. The table derives
`ROOT_PATHS`, and the six names the five test modules import are built from
it, so each filename is stated once.

**Trade rule misses name the card.** The promo branch cleared `art_style`
but left `shiny` as the classifier set it, so a promo print classified
shiny looked up `("Promo", True, None)` and missed the table. No promo set
has shipped a three-star print followed by a one or two star one, which is
what engages that path, so this was latent rather than live. The branch
normalises all three parts of the key now.

An unknown combination already raised, but a bare `KeyError` left whoever
is running the scrape with a tuple and no idea which card produced it. The
lookup goes through a helper naming the card and its number:

```
no trade rule for ('x', True, None) (card 'Mega Mewtwo', number '42')
```

**README.** The npm table covered `no-image` aliases for core and gameplay
but not collection, though the subpath ships in `package.json`. The size
table listed neither gameplay no-image (1.24 MB) nor collection no-image
(1.98 MB), and gave full as 4.58 MB against an actual 4.77 MB. Sizes are
measured from the committed minified files, tildes dropped.

**The trading fields on full.** `payloads.md` marked full as without
`tradable`, `sharable` and `trade_cost`. It carries all three on every one
of its 3,879 records; only core and gameplay drop them. Corrected in the
field comparison and in the per-payload section, with a test asserting the
keys are present on every record so the docs and data cannot drift apart
again silently.

Gate: 516 passed. No data changes.
